### PR TITLE
chore: rename app component title

### DIFF
--- a/konzertkompass/src/app/app.spec.ts
+++ b/konzertkompass/src/app/app.spec.ts
@@ -18,6 +18,6 @@ describe('App', () => {
     const fixture = TestBed.createComponent(App);
     fixture.detectChanges();
     const compiled = fixture.nativeElement as HTMLElement;
-    expect(compiled.querySelector('h1')?.textContent).toContain('Hello, konzertkompass');
+    expect(compiled.querySelector('h1')?.textContent).toContain('Hello, App');
   });
 });

--- a/konzertkompass/src/app/app.ts
+++ b/konzertkompass/src/app/app.ts
@@ -8,5 +8,5 @@ import { RouterOutlet } from '@angular/router';
   styleUrl: './app.scss'
 })
 export class App {
-  protected readonly title = signal('konzertkompass');
+  protected readonly title = signal('App');
 }


### PR DESCRIPTION
## Summary
- rename root Angular component title to "App"
- update tests to expect "Hello, App"

## Testing
- `npm test -- --watch=false` *(fails: No binary for Chrome browser on your platform)*

------
https://chatgpt.com/codex/tasks/task_e_6897011cb0c08326ba46d35760d60e95