### PR TITLE
feat: add musical ambiance to styles

### DIFF
--- a/frontend/src/app/band-list.component.scss
+++ b/frontend/src/app/band-list.component.scss
@@ -28,4 +28,11 @@ li {
   display: flex;
   justify-content: space-between;
   margin-bottom: 0.5rem;
+  align-items: center;
+}
+
+li::before {
+  content: '♪';
+  margin-right: 0.5rem;
+  color: #ff4081;
 }

--- a/frontend/src/app/login.component.scss
+++ b/frontend/src/app/login.component.scss
@@ -5,6 +5,14 @@
   margin-top: 2rem;
 }
 
+.login-container::before {
+  content: '♫';
+  display: block;
+  font-size: 3rem;
+  margin-bottom: 1rem;
+  color: #ff4081;
+}
+
 .profile img {
   width: 64px;
   height: 64px;

--- a/frontend/src/styles.scss
+++ b/frontend/src/styles.scss
@@ -1,10 +1,37 @@
 /* Global styles for the Konzertkompass frontend */
 
+@import url('https://fonts.googleapis.com/css2?family=Noto+Music&display=swap');
+
 body {
   margin: 0;
-  font-family: Arial, sans-serif;
+  font-family: 'Noto Music', Arial, sans-serif;
   background: linear-gradient(135deg, #1e3c72, #2a5298);
   color: #fff;
+  background-size: 400% 400%;
+  animation: gradient-move 15s ease infinite;
+  overflow-x: hidden;
+}
+
+@keyframes gradient-move {
+  0% {
+    background-position: 0% 50%;
+  }
+  50% {
+    background-position: 100% 50%;
+  }
+  100% {
+    background-position: 0% 50%;
+  }
+}
+
+body::after {
+  content: '♪ ♫ ♬';
+  position: fixed;
+  bottom: 1rem;
+  right: 1rem;
+  font-size: 3rem;
+  color: rgba(255, 255, 255, 0.2);
+  pointer-events: none;
 }
 
 .navbar {
@@ -12,6 +39,12 @@ body {
   display: flex;
   gap: 1rem;
   padding: 1rem;
+}
+
+.navbar::before {
+  content: '♫';
+  align-self: center;
+  margin-right: 0.5rem;
 }
 
 .navbar a {
@@ -28,4 +61,10 @@ button {
   border: none;
   color: #fff;
   border-radius: 4px;
+  transition: transform 0.2s;
+}
+
+button:hover {
+  transform: scale(1.05);
+  box-shadow: 0 0 10px rgba(255, 64, 129, 0.6);
 }


### PR DESCRIPTION
## Summary
- Animate global background gradient and import 'Noto Music' font
- Decorate navbar, band list items, and login view with musical notes
- Add hover effect to buttons for lively styling

## Testing
- `npm test -- --watch=false --browsers=ChromeHeadless` *(fails: No binary for ChromeHeadless browser)*

------
https://chatgpt.com/codex/tasks/task_e_68971e273ad88326bfb408c95294f2d4