### PR TITLE
feat: add google auth and band access control

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,13 @@
 # Konzertkompass
+
+## Development
+
+The frontend lives in `frontend/`. To run it locally with Google login, set your Google OAuth client ID and start the dev server:
+
+```bash
+cd frontend
+export NG_APP_GOOGLE_CLIENT_ID=your-google-client-id
+npm start
+```
+
+After logging in you can manage your band list.

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -8,6 +8,7 @@ This project was generated using [Angular CLI](https://github.com/angular/angula
 To start a local development server, run:
 
 ```bash
+export NG_APP_GOOGLE_CLIENT_ID=your-google-client-id
 ng serve
 ```
 

--- a/frontend/src/app/app.html
+++ b/frontend/src/app/app.html
@@ -1,6 +1,7 @@
 <nav class="navbar">
-  <a routerLink="/login" routerLinkActive="active">Login</a>
-  <a routerLink="/bands" routerLinkActive="active">Bands</a>
+  <a routerLink="/login" routerLinkActive="active" *ngIf="!auth.user()">Login</a>
+  <a routerLink="/bands" routerLinkActive="active" *ngIf="auth.user()">Bands</a>
+  <button *ngIf="auth.user()" (click)="logout()">Logout</button>
 </nav>
 <main>
   <router-outlet></router-outlet>

--- a/frontend/src/app/app.routes.ts
+++ b/frontend/src/app/app.routes.ts
@@ -1,4 +1,5 @@
 import { Routes } from '@angular/router';
+import { authGuard } from './auth.guard';
 
 export const routes: Routes = [
   {
@@ -10,6 +11,7 @@ export const routes: Routes = [
     path: 'bands',
     loadComponent: () =>
       import('./band-list.component').then((m) => m.BandListComponent),
+    canActivate: [authGuard],
   },
   { path: '', redirectTo: 'login', pathMatch: 'full' },
 ];

--- a/frontend/src/app/app.spec.ts
+++ b/frontend/src/app/app.spec.ts
@@ -1,10 +1,12 @@
 import { TestBed } from '@angular/core/testing';
 import { App } from './app';
+import { provideRouter } from '@angular/router';
 
 describe('App', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [App],
+      providers: [provideRouter([])],
     }).compileComponents();
   });
 
@@ -14,10 +16,10 @@ describe('App', () => {
     expect(app).toBeTruthy();
   });
 
-  it('should render title', () => {
+  it('should render navigation links', () => {
     const fixture = TestBed.createComponent(App);
     fixture.detectChanges();
     const compiled = fixture.nativeElement as HTMLElement;
-    expect(compiled.querySelector('h1')?.textContent).toContain('Hello, App');
+    expect(compiled.querySelector('nav')).toBeTruthy();
   });
 });

--- a/frontend/src/app/app.ts
+++ b/frontend/src/app/app.ts
@@ -1,5 +1,6 @@
 import { Component, signal } from '@angular/core';
-import { RouterOutlet, RouterLink, RouterLinkActive } from '@angular/router';
+import { Router, RouterOutlet, RouterLink, RouterLinkActive } from '@angular/router';
+import { AuthService } from './auth.service';
 
 @Component({
   selector: 'app-root',
@@ -9,4 +10,11 @@ import { RouterOutlet, RouterLink, RouterLinkActive } from '@angular/router';
 })
 export class App {
   protected readonly title = signal('Konzertkompass');
+
+  constructor(public auth: AuthService, private router: Router) {}
+
+  logout() {
+    this.auth.clearUser();
+    this.router.navigate(['/login']);
+  }
 }

--- a/frontend/src/app/auth.guard.ts
+++ b/frontend/src/app/auth.guard.ts
@@ -1,0 +1,13 @@
+import { CanActivateFn, Router } from '@angular/router';
+import { inject } from '@angular/core';
+import { AuthService } from './auth.service';
+
+export const authGuard: CanActivateFn = () => {
+  const auth = inject(AuthService);
+  const router = inject(Router);
+  if (!auth.isLoggedIn()) {
+    router.navigate(['/login']);
+    return false;
+  }
+  return true;
+};

--- a/frontend/src/app/auth.service.ts
+++ b/frontend/src/app/auth.service.ts
@@ -1,0 +1,18 @@
+import { Injectable, signal } from '@angular/core';
+
+@Injectable({ providedIn: 'root' })
+export class AuthService {
+  user = signal<any | null>(null);
+
+  setUser(user: any) {
+    this.user.set(user);
+  }
+
+  clearUser() {
+    this.user.set(null);
+  }
+
+  isLoggedIn(): boolean {
+    return this.user() !== null;
+  }
+}

--- a/frontend/src/app/login.component.html
+++ b/frontend/src/app/login.component.html
@@ -1,10 +1,10 @@
 <div class="login-container">
-  <div *ngIf="!user()">
+  <div *ngIf="!auth.user()">
     <div id="googleBtn"></div>
   </div>
-  <div *ngIf="user()" class="profile">
+  <div *ngIf="auth.user()" class="profile">
     <p>Token:</p>
-    <code>{{ user().credential }}</code>
+    <code>{{ auth.user().credential }}</code>
     <button (click)="signOut()">Sign out</button>
   </div>
 </div>

--- a/frontend/src/app/login.component.ts
+++ b/frontend/src/app/login.component.ts
@@ -1,5 +1,7 @@
-import { AfterViewInit, Component, signal } from '@angular/core';
+import { AfterViewInit, Component } from '@angular/core';
 import { CommonModule } from '@angular/common';
+import { Router } from '@angular/router';
+import { AuthService } from './auth.service';
 
 declare const google: any;
 
@@ -11,13 +13,16 @@ declare const google: any;
   styleUrl: './login.component.scss'
 })
 export class LoginComponent implements AfterViewInit {
-  user = signal<any | null>(null);
+  constructor(private auth: AuthService, private router: Router) {}
 
   ngAfterViewInit() {
     if (typeof google !== 'undefined') {
       google.accounts.id.initialize({
-        client_id: 'GOOGLE_CLIENT_ID',
-        callback: (resp: any) => this.user.set(resp),
+        client_id: (import.meta as any).env['NG_APP_GOOGLE_CLIENT_ID'] || 'GOOGLE_CLIENT_ID',
+        callback: (resp: any) => {
+          this.auth.setUser(resp);
+          this.router.navigate(['/bands']);
+        },
       });
       google.accounts.id.renderButton(
         document.getElementById('googleBtn'),
@@ -27,6 +32,6 @@ export class LoginComponent implements AfterViewInit {
   }
 
   signOut() {
-    this.user.set(null);
+    this.auth.clearUser();
   }
 }


### PR DESCRIPTION
## Summary
- document how to provide a Google OAuth client ID when running the frontend
- integrate Google sign-in backed by an AuthService and guard the band list route
- show login state in the navbar with a logout action

## Testing
- `npm test` *(fails: No binary for Chrome browser on your platform)*

------
https://chatgpt.com/codex/tasks/task_e_68971dd1eba88326ac71271d47c03006