### PR TITLE
feat: add band search with global suggestions

### DIFF
--- a/frontend/src/app/app.spec.ts
+++ b/frontend/src/app/app.spec.ts
@@ -14,10 +14,10 @@ describe('App', () => {
     expect(app).toBeTruthy();
   });
 
-  it('should render title', () => {
+  it('should render navigation', () => {
     const fixture = TestBed.createComponent(App);
     fixture.detectChanges();
     const compiled = fixture.nativeElement as HTMLElement;
-    expect(compiled.querySelector('h1')?.textContent).toContain('Hello, App');
+    expect(compiled.querySelector('nav')).toBeTruthy();
   });
 });

--- a/frontend/src/app/band-list.component.html
+++ b/frontend/src/app/band-list.component.html
@@ -1,12 +1,21 @@
 <div class="band-list">
-  <h2>Your Bands</h2>
-  <form (ngSubmit)="addBand()">
-    <input name="band" [(ngModel)]="newBand" placeholder="Add band" required />
-    <button type="submit">Add</button>
-  </form>
-  <ul>
+  <h2>Band Search</h2>
+  <input
+    name="band"
+    [(ngModel)]="searchTerm"
+    (ngModelChange)="search($event)"
+    placeholder="Search bands"
+  />
+  <ul *ngIf="suggestions.length">
+    <li *ngFor="let band of suggestions" (click)="addBand(band)">
+      {{ band.name }}
+    </li>
+  </ul>
+
+  <h3>Your Bands</h3>
+  <ul class="your-bands">
     <li *ngFor="let band of bands">
-      {{ band }}
+      {{ band.name }}
       <button (click)="removeBand(band)">Remove</button>
     </li>
   </ul>

--- a/frontend/src/app/band-list.component.scss
+++ b/frontend/src/app/band-list.component.scss
@@ -3,20 +3,10 @@
   margin: 2rem auto;
 }
 
-form {
-  display: flex;
-  gap: 0.5rem;
-  margin-bottom: 1rem;
-}
-
 input {
-  flex: 1;
+  width: 100%;
   padding: 0.5rem;
-}
-
-button {
-  padding: 0.5rem 1rem;
-  cursor: pointer;
+  margin-bottom: 0.5rem;
 }
 
 ul {
@@ -25,7 +15,11 @@ ul {
 }
 
 li {
+  padding: 0.25rem 0;
+  cursor: pointer;
+}
+
+.your-bands li {
   display: flex;
   justify-content: space-between;
-  margin-bottom: 0.5rem;
 }

--- a/frontend/src/app/band-list.component.ts
+++ b/frontend/src/app/band-list.component.ts
@@ -1,6 +1,8 @@
 import { Component } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
+import { BandSearchService } from './band-search.service';
+import { Band } from './models/band';
 
 @Component({
   selector: 'app-band-list',
@@ -10,18 +12,23 @@ import { FormsModule } from '@angular/forms';
   styleUrl: './band-list.component.scss'
 })
 export class BandListComponent {
-  newBand = '';
-  bands: string[] = [];
+  searchTerm = '';
+  suggestions: Band[] = [];
+  bands: Band[] = [];
 
-  addBand() {
-    const name = this.newBand.trim();
-    if (name) {
-      this.bands.push(name);
-      this.newBand = '';
-    }
+  constructor(private bandSearch: BandSearchService) {}
+
+  search(term: string) {
+    this.bandSearch.search(term).subscribe(bands => (this.suggestions = bands));
   }
 
-  removeBand(band: string) {
-    this.bands = this.bands.filter(b => b !== band);
+  addBand(band: Band) {
+    this.bands.push(band);
+    this.searchTerm = '';
+    this.suggestions = [];
+  }
+
+  removeBand(band: Band) {
+    this.bands = this.bands.filter(b => b.id !== band.id);
   }
 }

--- a/frontend/src/app/band-search.service.ts
+++ b/frontend/src/app/band-search.service.ts
@@ -1,0 +1,22 @@
+import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Observable, map, of } from 'rxjs';
+import { Band } from './models/band';
+
+@Injectable({ providedIn: 'root' })
+export class BandSearchService {
+  constructor(private http: HttpClient) {}
+
+  search(term: string): Observable<Band[]> {
+    if (!term.trim()) {
+      return of([]);
+    }
+
+    const url = `https://musicbrainz.org/ws/2/artist/?query=${encodeURIComponent(term)}&fmt=json&limit=10`;
+    return this.http.get<any>(url).pipe(
+      map((resp) =>
+        (resp.artists || []).map((a: any) => ({ id: a.id, name: a.name } as Band))
+      )
+    );
+  }
+}

--- a/frontend/src/app/models/band.ts
+++ b/frontend/src/app/models/band.ts
@@ -1,0 +1,4 @@
+export interface Band {
+  id: string;
+  name: string;
+}


### PR DESCRIPTION
## Summary
- add `Band` interface and search service to pull suggestions from MusicBrainz
- integrate search suggestions into `BandListComponent` UI
- update basic app test to verify navigation exists

## Testing
- `npm test -- --watch=false --browsers=ChromeHeadless` *(fails: No binary for ChromeHeadless)*

------
https://chatgpt.com/codex/tasks/task_e_68971ee1a8bc8326a9ad04dceca77099