### PR TITLE
fix: allow templates to access auth

### DIFF
--- a/frontend/src/app/app.ts
+++ b/frontend/src/app/app.ts
@@ -1,10 +1,12 @@
 import { Component, signal } from '@angular/core';
+import { NgIf } from '@angular/common';
 import { Router, RouterOutlet, RouterLink, RouterLinkActive } from '@angular/router';
 import { AuthService } from './auth.service';
 
 @Component({
   selector: 'app-root',
-  imports: [RouterOutlet, RouterLink, RouterLinkActive],
+  standalone: true,
+  imports: [RouterOutlet, RouterLink, RouterLinkActive, NgIf],
   templateUrl: './app.html',
   styleUrl: './app.scss'
 })

--- a/frontend/src/app/login.component.ts
+++ b/frontend/src/app/login.component.ts
@@ -12,8 +12,8 @@ declare const google: any;
   templateUrl: './login.component.html',
   styleUrl: './login.component.scss'
 })
-export class LoginComponent implements AfterViewInit {
-  constructor(private auth: AuthService, private router: Router) {}
+  export class LoginComponent implements AfterViewInit {
+    constructor(public auth: AuthService, private router: Router) {}
 
   ngAfterViewInit() {
     if (typeof google !== 'undefined') {


### PR DESCRIPTION
## Summary
- import NgIf and mark App component standalone to use *ngIf
- expose AuthService to templates by making it public

## Testing
- `npm test -- --watch=false --browsers=ChromeHeadless` *(fails: No binary for ChromeHeadless browser on your platform)*
- `npm run build` *(fails: Failed to inline external stylesheet 'https://fonts.googleapis.com/css2?family=Noto+Music&display=swap', status code: 403)*

------
https://chatgpt.com/codex/tasks/task_e_6897279a0f5c83269fc41a2fecd476f0