### PR TITLE
docs: clarify env var setup on Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,17 @@
 
 The frontend lives in `frontend/`. To run it locally with Google login, set your Google OAuth client ID and start the dev server:
 
+### macOS/Linux
 ```bash
 cd frontend
 export NG_APP_GOOGLE_CLIENT_ID=your-google-client-id
+npm start
+```
+
+### Windows PowerShell
+```powershell
+cd frontend
+$env:NG_APP_GOOGLE_CLIENT_ID="your-google-client-id"
 npm start
 ```
 

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -7,8 +7,15 @@ This project was generated using [Angular CLI](https://github.com/angular/angula
 
 To start a local development server, run:
 
+### macOS/Linux
 ```bash
 export NG_APP_GOOGLE_CLIENT_ID=your-google-client-id
+ng serve
+```
+
+### Windows PowerShell
+```powershell
+$env:NG_APP_GOOGLE_CLIENT_ID="your-google-client-id"
 ng serve
 ```
 


### PR DESCRIPTION
## Summary
- document how to set `NG_APP_GOOGLE_CLIENT_ID` on Windows PowerShell
- mirror platform-specific instructions in frontend README

## Testing
- `npm test -- --watch=false --browsers=ChromeHeadless` *(fails: No binary for ChromeHeadless browser on your platform)*

------
https://chatgpt.com/codex/tasks/task_e_68972aaeae048326a6b1a38b5fd73a96