### PR TITLE
feat: add local auth and fresh styling

### DIFF
--- a/frontend/src/app/auth.service.ts
+++ b/frontend/src/app/auth.service.ts
@@ -4,15 +4,46 @@ import { Injectable, signal } from '@angular/core';
 export class AuthService {
   user = signal<any | null>(null);
 
+  constructor() {
+    const stored = localStorage.getItem('currentUser');
+    if (stored) {
+      this.user.set(JSON.parse(stored));
+    }
+  }
+
   setUser(user: any) {
     this.user.set(user);
+    localStorage.setItem('currentUser', JSON.stringify(user));
   }
 
   clearUser() {
     this.user.set(null);
+    localStorage.removeItem('currentUser');
   }
 
   isLoggedIn(): boolean {
     return this.user() !== null;
+  }
+
+  register(username: string, password: string): boolean {
+    const users = JSON.parse(localStorage.getItem('users') || '[]');
+    if (users.some((u: any) => u.username === username)) {
+      return false;
+    }
+    users.push({ username, password });
+    localStorage.setItem('users', JSON.stringify(users));
+    return true;
+  }
+
+  login(username: string, password: string): boolean {
+    const users = JSON.parse(localStorage.getItem('users') || '[]');
+    const user = users.find(
+      (u: any) => u.username === username && u.password === password
+    );
+    if (user) {
+      this.setUser({ username: user.username });
+      return true;
+    }
+    return false;
   }
 }

--- a/frontend/src/app/band-list.component.scss
+++ b/frontend/src/app/band-list.component.scss
@@ -1,12 +1,19 @@
 .band-list {
-  max-width: 400px;
+  max-width: 500px;
   margin: 2rem auto;
+  padding: 1.5rem;
+  background: rgba(255, 255, 255, 0.1);
+  backdrop-filter: blur(6px);
+  border-radius: 16px;
+  box-shadow: 0 0 15px rgba(0, 0, 0, 0.5);
 }
 
 input {
   width: 100%;
   padding: 0.5rem;
   margin-bottom: 0.5rem;
+  border: none;
+  border-radius: 4px;
 }
 
 ul {

--- a/frontend/src/app/login.component.html
+++ b/frontend/src/app/login.component.html
@@ -1,10 +1,23 @@
 <div class="login-container">
   <div *ngIf="!auth.user()">
+    <div class="local-login">
+      <input type="text" [(ngModel)]="username" placeholder="Username" />
+      <input
+        type="password"
+        [(ngModel)]="password"
+        placeholder="Password"
+      />
+      <div class="buttons">
+        <button (click)="loginUser()">Login</button>
+        <button (click)="registerUser()">Register</button>
+      </div>
+      <p class="message" *ngIf="message">{{ message }}</p>
+    </div>
+    <div class="divider">or</div>
     <div id="googleBtn"></div>
   </div>
   <div *ngIf="auth.user()" class="profile">
-    <p>Token:</p>
-    <code>{{ auth.user().credential }}</code>
+    <p>Welcome {{ auth.user().username || 'friend' }}</p>
     <button (click)="signOut()">Sign out</button>
   </div>
 </div>

--- a/frontend/src/app/login.component.scss
+++ b/frontend/src/app/login.component.scss
@@ -2,15 +2,50 @@
   display: flex;
   flex-direction: column;
   align-items: center;
-  margin-top: 2rem;
+  margin-top: 3rem;
+  padding: 2rem;
+  background: rgba(255, 255, 255, 0.1);
+  backdrop-filter: blur(6px);
+  border-radius: 16px;
+  box-shadow: 0 0 20px rgba(0, 0, 0, 0.4);
 }
 
 .login-container::before {
-  content: '♫';
+  content: '★';
   display: block;
   font-size: 3rem;
   margin-bottom: 1rem;
+  color: #00e5ff;
+}
+
+.local-login {
+  display: flex;
+  flex-direction: column;
+  width: 250px;
+}
+
+.local-login input {
+  margin: 0.5rem 0;
+  padding: 0.5rem;
+  border: none;
+  border-radius: 4px;
+}
+
+.buttons {
+  display: flex;
+  gap: 0.5rem;
+  margin-top: 0.5rem;
+}
+
+.divider {
+  margin: 1rem 0;
+  color: #ccc;
+}
+
+.message {
   color: #ff4081;
+  margin-top: 0.5rem;
+  font-size: 0.9rem;
 }
 
 .profile img {

--- a/frontend/src/app/login.component.ts
+++ b/frontend/src/app/login.component.ts
@@ -1,5 +1,6 @@
 import { AfterViewInit, Component } from '@angular/core';
 import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
 import { Router } from '@angular/router';
 import { AuthService } from './auth.service';
 
@@ -8,17 +9,23 @@ declare const google: any;
 @Component({
   selector: 'app-login',
   standalone: true,
-  imports: [CommonModule],
+  imports: [CommonModule, FormsModule],
   templateUrl: './login.component.html',
   styleUrl: './login.component.scss'
 })
-  export class LoginComponent implements AfterViewInit {
-    constructor(public auth: AuthService, private router: Router) {}
+export class LoginComponent implements AfterViewInit {
+  username = '';
+  password = '';
+  message = '';
+
+  constructor(public auth: AuthService, private router: Router) {}
 
   ngAfterViewInit() {
     if (typeof google !== 'undefined') {
       google.accounts.id.initialize({
-        client_id: (import.meta as any).env['NG_APP_GOOGLE_CLIENT_ID'] || 'GOOGLE_CLIENT_ID',
+        client_id:
+          (import.meta as any).env['NG_APP_GOOGLE_CLIENT_ID'] ||
+          'GOOGLE_CLIENT_ID',
         callback: (resp: any) => {
           this.auth.setUser(resp);
           this.router.navigate(['/bands']);
@@ -28,6 +35,24 @@ declare const google: any;
         document.getElementById('googleBtn'),
         { theme: 'outline', size: 'large' }
       );
+    }
+  }
+
+  loginUser() {
+    if (this.auth.login(this.username, this.password)) {
+      this.router.navigate(['/bands']);
+    } else {
+      this.message = 'Invalid credentials';
+    }
+  }
+
+  registerUser() {
+    if (this.auth.register(this.username, this.password)) {
+      this.message = 'Registration successful. Please log in.';
+      this.username = '';
+      this.password = '';
+    } else {
+      this.message = 'Username already exists';
     }
   }
 

--- a/frontend/src/styles.scss
+++ b/frontend/src/styles.scss
@@ -5,24 +5,30 @@
 body {
   margin: 0;
   font-family: 'Noto Music', Arial, sans-serif;
-  background: linear-gradient(135deg, #1e3c72, #2a5298);
+  background-color: #0f0c29;
+  background-image: radial-gradient(
+      circle at 10% 20%,
+      rgba(255, 0, 150, 0.25) 0%,
+      transparent 60%
+    ),
+    radial-gradient(
+      circle at 80% 0%,
+      rgba(0, 200, 255, 0.25) 0%,
+      transparent 50%
+    ),
+    repeating-linear-gradient(
+      45deg,
+      rgba(255, 255, 255, 0.05) 0,
+      rgba(255, 255, 255, 0.05) 2px,
+      transparent 2px,
+      transparent 4px
+    ),
+    linear-gradient(135deg, #0f0c29, #302b63, #24243e);
+  background-size: 100% 100%, 100% 100%, 20px 20px, 100% 100%;
   color: #fff;
-  background-size: 400% 400%;
-  animation: gradient-move 15s ease infinite;
   overflow-x: hidden;
 }
 
-@keyframes gradient-move {
-  0% {
-    background-position: 0% 50%;
-  }
-  50% {
-    background-position: 100% 50%;
-  }
-  100% {
-    background-position: 0% 50%;
-  }
-}
 
 body::after {
   content: '♪ ♫ ♬';


### PR DESCRIPTION
## Summary
- add in-browser user database with registration and login
- revamp login flow with optional username/password alongside Google
- refresh overall look with patterned backgrounds and styled band list

## Testing
- `npm test` *(fails: No binary for Chrome browser on your platform)*

------
https://chatgpt.com/codex/tasks/task_e_689735df3f448326840a89e4bbe6e6b5