### PR TITLE
fix: guard localStorage for SSR

### DIFF
--- a/frontend/src/app/auth.service.ts
+++ b/frontend/src/app/auth.service.ts
@@ -1,11 +1,16 @@
-import { Injectable, signal } from '@angular/core';
+import { Injectable, signal, PLATFORM_ID, inject } from '@angular/core';
+import { isPlatformBrowser } from '@angular/common';
 
 @Injectable({ providedIn: 'root' })
 export class AuthService {
   user = signal<any | null>(null);
+  private readonly platformId = inject(PLATFORM_ID);
+  private storage = isPlatformBrowser(this.platformId)
+    ? window.localStorage
+    : null;
 
   constructor() {
-    const stored = localStorage.getItem('currentUser');
+    const stored = this.storage?.getItem('currentUser');
     if (stored) {
       this.user.set(JSON.parse(stored));
     }
@@ -13,12 +18,12 @@ export class AuthService {
 
   setUser(user: any) {
     this.user.set(user);
-    localStorage.setItem('currentUser', JSON.stringify(user));
+    this.storage?.setItem('currentUser', JSON.stringify(user));
   }
 
   clearUser() {
     this.user.set(null);
-    localStorage.removeItem('currentUser');
+    this.storage?.removeItem('currentUser');
   }
 
   isLoggedIn(): boolean {
@@ -26,17 +31,17 @@ export class AuthService {
   }
 
   register(username: string, password: string): boolean {
-    const users = JSON.parse(localStorage.getItem('users') || '[]');
+    const users = JSON.parse(this.storage?.getItem('users') || '[]');
     if (users.some((u: any) => u.username === username)) {
       return false;
     }
     users.push({ username, password });
-    localStorage.setItem('users', JSON.stringify(users));
+    this.storage?.setItem('users', JSON.stringify(users));
     return true;
   }
 
   login(username: string, password: string): boolean {
-    const users = JSON.parse(localStorage.getItem('users') || '[]');
+    const users = JSON.parse(this.storage?.getItem('users') || '[]');
     const user = users.find(
       (u: any) => u.username === username && u.password === password
     );


### PR DESCRIPTION
## Summary
- guard browser-only localStorage access in AuthService via PLATFORM_ID and `isPlatformBrowser`
- ensure user persistence and auth actions use storage only when available

## Testing
- `npm run build` *(fails: Inlining of fonts failed, status code 403)*
- `npm test -- --watch=false --browsers=ChromeHeadless` *(fails: No binary for ChromeHeadless)*

------
https://chatgpt.com/codex/tasks/task_e_68973c36dc908326b84205a3dcbd7799