### PR TITLE
feat: allow public band search and custom background

### DIFF
--- a/frontend/src/app/app.html
+++ b/frontend/src/app/app.html
@@ -1,6 +1,6 @@
 <nav class="navbar">
   <a routerLink="/login" routerLinkActive="active" *ngIf="!auth.user()">Login</a>
-  <a routerLink="/bands" routerLinkActive="active" *ngIf="auth.user()">Bands</a>
+  <a routerLink="/bands" routerLinkActive="active">Bands</a>
   <button *ngIf="auth.user()" (click)="logout()">Logout</button>
 </nav>
 <main>

--- a/frontend/src/app/app.routes.ts
+++ b/frontend/src/app/app.routes.ts
@@ -1,5 +1,4 @@
 import { Routes } from '@angular/router';
-import { authGuard } from './auth.guard';
 
 export const routes: Routes = [
   {
@@ -11,7 +10,6 @@ export const routes: Routes = [
     path: 'bands',
     loadComponent: () =>
       import('./band-list.component').then((m) => m.BandListComponent),
-    canActivate: [authGuard],
   },
   { path: '', redirectTo: 'login', pathMatch: 'full' },
 ];

--- a/frontend/src/app/app.ts
+++ b/frontend/src/app/app.ts
@@ -2,6 +2,7 @@ import { Component, signal } from '@angular/core';
 import { NgIf } from '@angular/common';
 import { Router, RouterOutlet, RouterLink, RouterLinkActive } from '@angular/router';
 import { AuthService } from './auth.service';
+import { BackgroundService } from './background.service';
 
 @Component({
   selector: 'app-root',
@@ -13,7 +14,13 @@ import { AuthService } from './auth.service';
 export class App {
   protected readonly title = signal('Konzertkompass');
 
-  constructor(public auth: AuthService, private router: Router) {}
+  constructor(
+    public auth: AuthService,
+    private router: Router,
+    private bg: BackgroundService
+  ) {
+    this.bg.loadSavedBackground();
+  }
 
   logout() {
     this.auth.clearUser();

--- a/frontend/src/app/auth.service.ts
+++ b/frontend/src/app/auth.service.ts
@@ -5,25 +5,26 @@ import { isPlatformBrowser } from '@angular/common';
 export class AuthService {
   user = signal<any | null>(null);
   private readonly platformId = inject(PLATFORM_ID);
-  private storage = isPlatformBrowser(this.platformId)
-    ? window.localStorage
-    : null;
 
   constructor() {
-    const stored = this.storage?.getItem('currentUser');
+    const stored = this.getStorage()?.getItem('currentUser');
     if (stored) {
       this.user.set(JSON.parse(stored));
     }
   }
 
+  private getStorage(): Storage | null {
+    return isPlatformBrowser(this.platformId) ? window.localStorage : null;
+  }
+
   setUser(user: any) {
     this.user.set(user);
-    this.storage?.setItem('currentUser', JSON.stringify(user));
+    this.getStorage()?.setItem('currentUser', JSON.stringify(user));
   }
 
   clearUser() {
     this.user.set(null);
-    this.storage?.removeItem('currentUser');
+    this.getStorage()?.removeItem('currentUser');
   }
 
   isLoggedIn(): boolean {
@@ -31,17 +32,22 @@ export class AuthService {
   }
 
   register(username: string, password: string): boolean {
-    const users = JSON.parse(this.storage?.getItem('users') || '[]');
+    const storage = this.getStorage();
+    if (!storage) {
+      return false;
+    }
+    const users = JSON.parse(storage.getItem('users') || '[]');
     if (users.some((u: any) => u.username === username)) {
       return false;
     }
     users.push({ username, password });
-    this.storage?.setItem('users', JSON.stringify(users));
+    storage.setItem('users', JSON.stringify(users));
     return true;
   }
 
   login(username: string, password: string): boolean {
-    const users = JSON.parse(this.storage?.getItem('users') || '[]');
+    const storage = this.getStorage();
+    const users = JSON.parse(storage?.getItem('users') || '[]');
     const user = users.find(
       (u: any) => u.username === username && u.password === password
     );

--- a/frontend/src/app/background-selector.component.html
+++ b/frontend/src/app/background-selector.component.html
@@ -1,0 +1,6 @@
+<div class="background-selector">
+  <p>Choose a background</p>
+  <div class="images">
+    <img *ngFor="let img of images" [src]="img" (click)="select(img)" />
+  </div>
+</div>

--- a/frontend/src/app/background-selector.component.scss
+++ b/frontend/src/app/background-selector.component.scss
@@ -1,0 +1,19 @@
+.background-selector {
+  text-align: center;
+  .images {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+    justify-content: center;
+    img {
+      width: 120px;
+      height: 80px;
+      object-fit: cover;
+      cursor: pointer;
+      border: 2px solid transparent;
+    }
+    img:hover {
+      border-color: #666;
+    }
+  }
+}

--- a/frontend/src/app/background-selector.component.ts
+++ b/frontend/src/app/background-selector.component.ts
@@ -1,0 +1,22 @@
+import { Component } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { BackgroundService } from './background.service';
+
+@Component({
+  selector: 'app-background-selector',
+  standalone: true,
+  imports: [CommonModule],
+  templateUrl: './background-selector.component.html',
+  styleUrl: './background-selector.component.scss'
+})
+export class BackgroundSelectorComponent {
+  images: string[];
+
+  constructor(private bg: BackgroundService) {
+    this.images = this.bg.getSuggestions();
+  }
+
+  select(url: string) {
+    this.bg.setBackground(url);
+  }
+}

--- a/frontend/src/app/background.service.ts
+++ b/frontend/src/app/background.service.ts
@@ -1,0 +1,28 @@
+import { Injectable } from '@angular/core';
+
+@Injectable({ providedIn: 'root' })
+export class BackgroundService {
+  getSuggestions(count = 5): string[] {
+    return Array.from({ length: count }, (_, i) =>
+      `https://source.unsplash.com/1600x900/?band&sig=${i}`
+    );
+  }
+
+  setBackground(url: string) {
+    if (typeof document !== 'undefined') {
+      document.body.style.backgroundImage = `url(${url})`;
+    }
+    if (typeof window !== 'undefined') {
+      window.localStorage.setItem('background', url);
+    }
+  }
+
+  loadSavedBackground() {
+    if (typeof window !== 'undefined') {
+      const url = window.localStorage.getItem('background');
+      if (url) {
+        this.setBackground(url);
+      }
+    }
+  }
+}

--- a/frontend/src/app/login.component.html
+++ b/frontend/src/app/login.component.html
@@ -1,4 +1,5 @@
 <div class="login-container">
+  <app-background-selector></app-background-selector>
   <div *ngIf="!auth.user()">
     <div class="local-login">
       <input type="text" [(ngModel)]="username" placeholder="Username" />

--- a/frontend/src/app/login.component.ts
+++ b/frontend/src/app/login.component.ts
@@ -3,13 +3,14 @@ import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { Router } from '@angular/router';
 import { AuthService } from './auth.service';
+import { BackgroundSelectorComponent } from './background-selector.component';
 
 declare const google: any;
 
 @Component({
   selector: 'app-login',
   standalone: true,
-  imports: [CommonModule, FormsModule],
+  imports: [CommonModule, FormsModule, BackgroundSelectorComponent],
   templateUrl: './login.component.html',
   styleUrl: './login.component.scss'
 })


### PR DESCRIPTION
## Summary
- remove login requirement for band list and expose "Bands" tab to all users
- fix AuthService storage handling and persist users in local storage
- add background selector using band images from Unsplash and apply selection site-wide

## Testing
- `npm test --silent` *(fails: No binary for Chrome browser)*
- `apt-get update` *(fails: repository not signed)*
- `npm run build --silent` *(fails: 403 fetching google fonts)*

------
https://chatgpt.com/codex/tasks/task_e_689743e665808326a8bbbf57f4f248ce