### PR TITLE
Show upcoming band events during search

### DIFF
--- a/frontend/src/app/band-list.component.html
+++ b/frontend/src/app/band-list.component.html
@@ -6,17 +6,31 @@
     (ngModelChange)="search($event)"
     placeholder="Search bands"
   />
-  <ul *ngIf="suggestions.length">
-    <li *ngFor="let band of suggestions" (click)="addBand(band)">
-      {{ band.name }}
-    </li>
-  </ul>
+    <ul *ngIf="suggestions.length">
+      <li *ngFor="let band of suggestions" (click)="addBand(band)">
+        <div class="band-name">{{ band.name }}</div>
+        <ul class="events" *ngIf="band.upcomingEvents?.length">
+          <li *ngFor="let event of band.upcomingEvents">{{ event }}</li>
+        </ul>
+        <div class="events" *ngIf="band.upcomingEvents && !band.upcomingEvents.length">
+          <em>Keine Auftritte in den nächsten 3 Wochen</em>
+        </div>
+      </li>
+    </ul>
 
-  <h3>Your Bands</h3>
-  <ul class="your-bands">
-    <li *ngFor="let band of bands">
-      {{ band.name }}
-      <button (click)="removeBand(band)">Remove</button>
-    </li>
-  </ul>
+    <h3>Your Bands</h3>
+    <ul class="your-bands">
+      <li *ngFor="let band of bands">
+        <div class="band-name">
+          {{ band.name }}
+          <button (click)="removeBand(band); $event.stopPropagation()">Remove</button>
+        </div>
+        <ul class="events" *ngIf="band.upcomingEvents?.length">
+          <li *ngFor="let event of band.upcomingEvents">{{ event }}</li>
+        </ul>
+        <div class="events" *ngIf="band.upcomingEvents && !band.upcomingEvents.length">
+          <em>Keine Auftritte in den nächsten 3 Wochen</em>
+        </div>
+      </li>
+    </ul>
 </div>

--- a/frontend/src/app/band-list.component.scss
+++ b/frontend/src/app/band-list.component.scss
@@ -38,3 +38,17 @@ li::before {
   margin-right: 0.5rem;
   color: #ff4081;
 }
+
+.events {
+  margin-left: 1rem;
+  font-size: 0.9rem;
+  cursor: default;
+}
+
+.events li::before {
+  content: '🎤';
+}
+
+.events li {
+  cursor: default;
+}

--- a/frontend/src/app/band-search.service.ts
+++ b/frontend/src/app/band-search.service.ts
@@ -1,6 +1,13 @@
 import { Injectable } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
-import { Observable, map, of } from 'rxjs';
+import {
+  Observable,
+  map,
+  of,
+  switchMap,
+  forkJoin,
+  catchError,
+} from 'rxjs';
 import { Band } from './models/band';
 
 @Injectable({ providedIn: 'root' })
@@ -12,11 +19,42 @@ export class BandSearchService {
       return of([]);
     }
 
-    const url = `https://musicbrainz.org/ws/2/artist/?query=${encodeURIComponent(term)}&fmt=json&limit=10`;
+    const url = `https://musicbrainz.org/ws/2/artist/?query=${encodeURIComponent(
+      term
+    )}&fmt=json&limit=10`;
     return this.http.get<any>(url).pipe(
-      map((resp) =>
-        (resp.artists || []).map((a: any) => ({ id: a.id, name: a.name } as Band))
-      )
+      switchMap((resp) => {
+        const bands = (resp.artists || []).map(
+          (a: any) => ({ id: a.id, name: a.name } as Band)
+        );
+        if (!bands.length) {
+          return of([]);
+        }
+        const requests = bands.map((band: Band) =>
+          this.getUpcomingEvents(band.id).pipe(
+            map((events) => ({ ...band, upcomingEvents: events }))
+          )
+        );
+        return forkJoin(requests) as Observable<Band[]>;
+      })
+    );
+  }
+
+  private getUpcomingEvents(id: string): Observable<string[]> {
+    const url = `https://musicbrainz.org/ws/2/event?artist=${id}&fmt=json`;
+    return this.http.get<any>(url).pipe(
+      map((resp) => {
+        const today = new Date();
+        const cutoff = new Date();
+        cutoff.setDate(today.getDate() + 21);
+        return (resp.events || [])
+          .map((e: any) => e['life-span']?.begin)
+          .filter((d: string) => {
+            const date = new Date(d);
+            return date >= today && date <= cutoff;
+          });
+      }),
+      catchError(() => of([]))
     );
   }
 }

--- a/frontend/src/app/models/band.ts
+++ b/frontend/src/app/models/band.ts
@@ -1,4 +1,5 @@
 export interface Band {
   id: string;
   name: string;
+  upcomingEvents?: string[];
 }


### PR DESCRIPTION
## Summary
- extend Band model with upcoming events
- fetch next 3 weeks of events from MusicBrainz for search results
- display upcoming dates beneath bands with simple styling

## Testing
- `npm test` *(fails: No binary for Chrome browser on your platform)*
- `npm run build` *(fails: Inlining of fonts failed, https://fonts.googleapis.com/css2... returned status code 403)*

------
https://chatgpt.com/codex/tasks/task_e_689a10504f108326b24138d3b1cd434d