### PR TITLE
feat: redesign landing page with local music wallpapers

### DIFF
--- a/frontend/public/images/bg1.svg
+++ b/frontend/public/images/bg1.svg
@@ -1,0 +1,12 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1920" height="1080">
+  <defs>
+    <linearGradient id="grad1" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#0f0c29"/>
+      <stop offset="100%" stop-color="#302b63"/>
+    </linearGradient>
+  </defs>
+  <rect width="100%" height="100%" fill="url(#grad1)"/>
+  <text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" font-size="400" fill="rgba(255,255,255,0.1)">♫</text>
+  <text x="20%" y="30%" font-size="200" fill="rgba(255,255,255,0.05)">♪</text>
+  <text x="80%" y="70%" font-size="250" fill="rgba(255,255,255,0.05)">♬</text>
+</svg>

--- a/frontend/public/images/bg2.svg
+++ b/frontend/public/images/bg2.svg
@@ -1,0 +1,12 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1920" height="1080">
+  <defs>
+    <linearGradient id="grad2" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#3a1c71"/>
+      <stop offset="100%" stop-color="#d76d77"/>
+    </linearGradient>
+  </defs>
+  <rect width="100%" height="100%" fill="url(#grad2)"/>
+  <text x="30%" y="40%" font-size="300" fill="rgba(255,255,255,0.1)">♩</text>
+  <text x="70%" y="60%" font-size="260" fill="rgba(255,255,255,0.08)">♪</text>
+  <text x="50%" y="80%" font-size="220" fill="rgba(255,255,255,0.06)">♬</text>
+</svg>

--- a/frontend/public/images/bg3.svg
+++ b/frontend/public/images/bg3.svg
@@ -1,0 +1,12 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1920" height="1080">
+  <defs>
+    <linearGradient id="grad3" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0%" stop-color="#355c7d"/>
+      <stop offset="100%" stop-color="#c06c84"/>
+    </linearGradient>
+  </defs>
+  <rect width="100%" height="100%" fill="url(#grad3)"/>
+  <text x="25%" y="75%" font-size="240" fill="rgba(255,255,255,0.08)">♫</text>
+  <text x="75%" y="35%" font-size="280" fill="rgba(255,255,255,0.07)">♩</text>
+  <text x="50%" y="30%" font-size="180" fill="rgba(255,255,255,0.05)">♪</text>
+</svg>

--- a/frontend/src/app/background-selector.component.html
+++ b/frontend/src/app/background-selector.component.html
@@ -1,5 +1,5 @@
 <div class="background-selector">
-  <p>Choose a background</p>
+  <p>Wallpaper auswählen</p>
   <div class="images">
     <img *ngFor="let img of images" [src]="img" (click)="select(img)" />
   </div>

--- a/frontend/src/app/background-selector.component.scss
+++ b/frontend/src/app/background-selector.component.scss
@@ -1,5 +1,9 @@
 .background-selector {
   text-align: center;
+  margin-top: 1rem;
+  p {
+    margin-bottom: 0.5rem;
+  }
   .images {
     display: flex;
     flex-wrap: wrap;
@@ -11,9 +15,10 @@
       object-fit: cover;
       cursor: pointer;
       border: 2px solid transparent;
+      border-radius: 4px;
     }
     img:hover {
-      border-color: #666;
+      border-color: #ff4081;
     }
   }
 }

--- a/frontend/src/app/background.service.ts
+++ b/frontend/src/app/background.service.ts
@@ -2,15 +2,18 @@ import { Injectable } from '@angular/core';
 
 @Injectable({ providedIn: 'root' })
 export class BackgroundService {
-  getSuggestions(count = 5): string[] {
-    return Array.from({ length: count }, (_, i) =>
-      `https://source.unsplash.com/1600x900/?band&sig=${i}`
-    );
+  private images = ['images/bg1.svg', 'images/bg2.svg', 'images/bg3.svg'];
+
+  getSuggestions(): string[] {
+    return this.images;
   }
 
   setBackground(url: string) {
     if (typeof document !== 'undefined') {
-      document.body.style.backgroundImage = `url(${url})`;
+      document.body.style.backgroundImage = `linear-gradient(rgba(0,0,0,0.5), rgba(0,0,0,0.5)), url(${url})`;
+      document.body.style.backgroundSize = 'cover';
+      document.body.style.backgroundRepeat = 'no-repeat';
+      document.body.style.backgroundPosition = 'center';
     }
     if (typeof window !== 'undefined') {
       window.localStorage.setItem('background', url);

--- a/frontend/src/app/login.component.html
+++ b/frontend/src/app/login.component.html
@@ -1,24 +1,28 @@
 <div class="login-container">
-  <app-background-selector></app-background-selector>
-  <div *ngIf="!auth.user()">
+  <h1 class="title">Konzertkompass</h1>
+  <p class="tagline">Finde deinen Rhythmus</p>
+
+  <div *ngIf="!auth.user()" class="auth-box">
     <div class="local-login">
-      <input type="text" [(ngModel)]="username" placeholder="Username" />
+      <input type="text" [(ngModel)]="username" placeholder="Benutzername" />
       <input
         type="password"
         [(ngModel)]="password"
-        placeholder="Password"
+        placeholder="Passwort"
       />
       <div class="buttons">
         <button (click)="loginUser()">Login</button>
-        <button (click)="registerUser()">Register</button>
+        <button (click)="registerUser()">Registrieren</button>
       </div>
       <p class="message" *ngIf="message">{{ message }}</p>
     </div>
-    <div class="divider">or</div>
+    <div class="divider">oder</div>
     <div id="googleBtn"></div>
   </div>
   <div *ngIf="auth.user()" class="profile">
     <p>Welcome {{ auth.user().username || 'friend' }}</p>
     <button (click)="signOut()">Sign out</button>
   </div>
+
+  <app-background-selector></app-background-selector>
 </div>

--- a/frontend/src/app/login.component.scss
+++ b/frontend/src/app/login.component.scss
@@ -2,20 +2,37 @@
   display: flex;
   flex-direction: column;
   align-items: center;
-  margin-top: 3rem;
-  padding: 2rem;
-  background: rgba(255, 255, 255, 0.1);
+  margin-top: 10vh;
+  padding: 2rem 3rem;
+  background: rgba(0, 0, 0, 0.5);
   backdrop-filter: blur(6px);
   border-radius: 16px;
-  box-shadow: 0 0 20px rgba(0, 0, 0, 0.4);
+  box-shadow: 0 0 20px rgba(0, 0, 0, 0.6);
+  text-align: center;
 }
 
 .login-container::before {
-  content: '★';
+  content: '\266B';
   display: block;
   font-size: 3rem;
-  margin-bottom: 1rem;
-  color: #00e5ff;
+  margin-bottom: 0.5rem;
+  color: #ff4081;
+}
+
+.title {
+  margin: 0;
+  font-size: 2.5rem;
+}
+
+.tagline {
+  margin: 0 0 2rem 0;
+  color: #ccc;
+}
+
+.auth-box {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
 }
 
 .local-login {


### PR DESCRIPTION
## Summary
- Add three local SVG wallpapers and update background service to load them with a dark overlay for readability
- Refresh login page layout with musical title, tagline and centered auth box
- Polish wallpaper selector styling and wording

## Testing
- `npm test -- --watch=false` *(fails: No binary for Chrome browser on your platform)*
- `apt-get update` *(fails: repository ... InRelease is not signed / 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_689a14c2bbd48326a6006b3a07a5ed88