### PR TITLE
Handle search errors gracefully

### DIFF
--- a/frontend/src/app/band-search.service.ts
+++ b/frontend/src/app/band-search.service.ts
@@ -34,7 +34,8 @@ export class BandSearchService {
         bands
           .filter((b) => b.name.toLowerCase().startsWith(lower))
           .slice(0, 10)
-      )
+      ),
+      catchError(() => of([]))
     );
   }
 }


### PR DESCRIPTION
## Summary
- Return an empty list when band search encounters an error

## Testing
- `npm test` *(fails: No binary for Chrome browser on your platform)*

------
https://chatgpt.com/codex/tasks/task_e_689a35cd0da88326bcc763fafdb64af5