### PR TITLE
Add startup scripts and README guidance

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,1 @@
+NG_APP_GOOGLE_CLIENT_ID=your-google-client-id

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 node_modules/
 package-lock.json
+
+.env

--- a/README.md
+++ b/README.md
@@ -1,17 +1,39 @@
 # Konzertkompass
 
-## Development
+## Getting Started
 
-The frontend lives in `frontend/`. To run it locally with Google login, set your Google OAuth client ID and start the dev server:
+1. Install a current Node.js LTS version.
+2. Copy `.env.example` to `.env` and replace the placeholder with your Google OAuth client ID.
 
-### macOS/Linux
+### Development server
+
+```bash
+./start-dev.sh
+```
+
+The script installs dependencies and launches the Angular dev server on <http://localhost:4200>.
+
+### Production build served locally
+
+```bash
+./run-prod.sh
+```
+
+This performs a clean install, builds the app with the production configuration
+and serves `dist/frontend` via [`serve`](https://www.npmjs.com/package/serve)
+on <http://localhost:8080>. Set a different port using
+`PORT=3000 ./run-prod.sh`.
+
+### Manual development steps (alternative)
+
+#### macOS/Linux
 ```bash
 cd frontend
 export NG_APP_GOOGLE_CLIENT_ID=your-google-client-id
 npm start
 ```
 
-### Windows PowerShell
+#### Windows PowerShell
 ```powershell
 cd frontend
 $env:NG_APP_GOOGLE_CLIENT_ID="your-google-client-id"
@@ -20,5 +42,24 @@ npm start
 
 After logging in you can manage your band list.
 
+## Deployment notes
+
+For production deployments you can copy the content of `frontend/dist/frontend`
+to a web server such as Nginx:
+
+```nginx
+server {
+    listen 80;
+    server_name example.com;
+    root /path/to/dist/frontend;
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+}
+```
+
+Run `sudo nginx -t` and `sudo systemctl reload nginx` to apply the configuration.
+
 ## License
+
 © 2024 Christian Meyer. All rights reserved.

--- a/run-prod.sh
+++ b/run-prod.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$SCRIPT_DIR/frontend"
+
+# Install dependencies
+npm ci
+
+# Production build
+npm run build -- --configuration production
+
+# Serve static files
+npx serve -l "${PORT:-8080}" dist/frontend

--- a/start-dev.sh
+++ b/start-dev.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+if [ -f "$SCRIPT_DIR/.env" ]; then
+  # shellcheck disable=SC1091
+  source "$SCRIPT_DIR/.env"
+fi
+
+if [ -z "$NG_APP_GOOGLE_CLIENT_ID" ]; then
+  echo "NG_APP_GOOGLE_CLIENT_ID is not set. Create a .env file or export it before running this script." >&2
+  exit 1
+fi
+
+cd "$SCRIPT_DIR/frontend"
+
+npm install
+
+npm start


### PR DESCRIPTION
## Summary
- provide start-dev.sh and run-prod.sh scripts to automate local development and production builds
- document quick start, production serving and Nginx deployment notes in README
- add .env.example and ignore local .env files

## Testing
- `npm test` *(fails: No binary for Chrome browser on your platform)*

------
https://chatgpt.com/codex/tasks/task_e_689a36e76a188326a40d861c8def3ced