### PR TITLE
docs: add compose pull-refresh dependency notes

### DIFF
--- a/docs/pull-refresh.md
+++ b/docs/pull-refresh.md
@@ -1,0 +1,20 @@
+# Compose Pull Refresh Dependency
+
+To use the experimental pull-to-refresh APIs in Jetpack Compose, add the following dependency in your module's `build.gradle`:
+
+```kotlin
+dependencies {
+    implementation("androidx.compose.material:pull-refresh:1.5.0")
+}
+```
+
+Then import the APIs:
+
+```kotlin
+import androidx.compose.material.ExperimentalMaterialApi
+import androidx.compose.material.pullrefresh.PullRefreshIndicator
+import androidx.compose.material.pullrefresh.pullRefresh
+import androidx.compose.material.pullrefresh.rememberPullRefreshState
+```
+
+Because the API is marked `@ExperimentalMaterialApi`, annotate your composable or file with `@OptIn(ExperimentalMaterialApi::class)` if necessary.


### PR DESCRIPTION
## Summary
- document how to add Jetpack Compose pull-refresh dependency and imports

## Testing
- `npm test` *(fails: No binary for Chrome browser on your platform)*

------
https://chatgpt.com/codex/tasks/task_e_689a564a95f48326b6f98a2e17ffd8d7