### PR TITLE
feat: add global band search tab

### DIFF
--- a/frontend/src/app/app.html
+++ b/frontend/src/app/app.html
@@ -1,6 +1,7 @@
 <nav class="navbar">
   <a routerLink="/login" routerLinkActive="active" *ngIf="!auth.user()">Login</a>
   <a routerLink="/bands" routerLinkActive="active">Bands</a>
+  <a routerLink="/bands2" routerLinkActive="active">Band2</a>
   <button *ngIf="auth.user()" (click)="logout()">Logout</button>
 </nav>
 <main>

--- a/frontend/src/app/app.routes.ts
+++ b/frontend/src/app/app.routes.ts
@@ -11,5 +11,10 @@ export const routes: Routes = [
     loadComponent: () =>
       import('./band-list.component').then((m) => m.BandListComponent),
   },
+  {
+    path: 'bands2',
+    loadComponent: () =>
+      import('./band2-list.component').then((m) => m.Band2ListComponent),
+  },
   { path: '', redirectTo: 'login', pathMatch: 'full' },
 ];

--- a/frontend/src/app/band2-list.component.html
+++ b/frontend/src/app/band2-list.component.html
@@ -1,0 +1,11 @@
+<div class="band2-search">
+  <input
+    type="text"
+    [(ngModel)]="searchTerm"
+    (ngModelChange)="search($event)"
+    placeholder="Suche Bands weltweit..."
+  />
+  <ul *ngIf="suggestions.length">
+    <li *ngFor="let band of suggestions">{{ band.name }}</li>
+  </ul>
+</div>

--- a/frontend/src/app/band2-list.component.scss
+++ b/frontend/src/app/band2-list.component.scss
@@ -1,0 +1,14 @@
+.band2-search {
+  input {
+    width: 100%;
+    padding: 0.5rem;
+  }
+  ul {
+    list-style: none;
+    padding: 0;
+    margin-top: 0.5rem;
+    li {
+      padding: 0.25rem 0;
+    }
+  }
+}

--- a/frontend/src/app/band2-list.component.ts
+++ b/frontend/src/app/band2-list.component.ts
@@ -1,0 +1,41 @@
+import { Component, OnDestroy, OnInit } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import { WorldBandSearchService } from './world-band-search.service';
+import { Band } from './models/band';
+import { Subject, Subscription, debounceTime, distinctUntilChanged, switchMap } from 'rxjs';
+
+@Component({
+  selector: 'app-band2-list',
+  standalone: true,
+  imports: [CommonModule, FormsModule],
+  templateUrl: './band2-list.component.html',
+  styleUrl: './band2-list.component.scss'
+})
+export class Band2ListComponent implements OnInit, OnDestroy {
+  searchTerm = '';
+  suggestions: Band[] = [];
+
+  private searchTerms = new Subject<string>();
+  private searchSub?: Subscription;
+
+  constructor(private bandSearch: WorldBandSearchService) {}
+
+  ngOnInit() {
+    this.searchSub = this.searchTerms
+      .pipe(
+        debounceTime(300),
+        distinctUntilChanged(),
+        switchMap((term: string) => this.bandSearch.search(term))
+      )
+      .subscribe((bands) => (this.suggestions = bands));
+  }
+
+  ngOnDestroy() {
+    this.searchSub?.unsubscribe();
+  }
+
+  search(term: string) {
+    this.searchTerms.next(term);
+  }
+}

--- a/frontend/src/app/world-band-search.service.ts
+++ b/frontend/src/app/world-band-search.service.ts
@@ -1,0 +1,29 @@
+import { Injectable } from '@angular/core';
+import { HttpClient, HttpParams } from '@angular/common/http';
+import { Observable, of, map, catchError } from 'rxjs';
+import { Band } from './models/band';
+
+@Injectable({ providedIn: 'root' })
+export class WorldBandSearchService {
+  constructor(private http: HttpClient) {}
+
+  search(term: string): Observable<Band[]> {
+    if (!term.trim()) {
+      return of([]);
+    }
+    const params = new HttpParams()
+      .set('query', term)
+      .set('fmt', 'json')
+      .set('limit', '10');
+    return this.http
+      .get<any>('https://musicbrainz.org/ws/2/artist', { params })
+      .pipe(
+        map((res) =>
+          (res.artists || [])
+            .sort((a: any, b: any) => (b.score || 0) - (a.score || 0))
+            .map((artist: any) => ({ id: artist.id, name: artist.name }))
+        ),
+        catchError(() => of([]))
+      );
+  }
+}


### PR DESCRIPTION
## Summary
- add Band2 tab and routing
- implement world band search service using MusicBrainz API
- create Band2 component with search suggestions

## Testing
- `npm test` *(fails: No binary for Chrome browser on your platform)*

------
https://chatgpt.com/codex/tasks/task_e_689a5ad16acc83269261b5be20419be5