### PR TITLE
Animate map and add TESTBAND mock event

### DIFF
--- a/frontend/src/app/band-events.service.spec.ts
+++ b/frontend/src/app/band-events.service.spec.ts
@@ -1,0 +1,25 @@
+import { TestBed } from '@angular/core/testing';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { BandEventsService } from './band-events.service';
+
+describe('BandEventsService', () => {
+  let service: BandEventsService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule],
+    });
+    service = TestBed.inject(BandEventsService);
+  });
+
+  it('returns mock event for TESTBAND', (done) => {
+    service.getUpcomingInGermany('TESTBAND').subscribe((events) => {
+      expect(events.length).toBe(1);
+      const event = events[0];
+      expect(event.venue.name).toBe('Berlin Arena');
+      expect(event.venue.latitude).toBe('52.5200');
+      expect(event.venue.longitude).toBe('13.4050');
+      done();
+    });
+  });
+});

--- a/frontend/src/app/band-events.service.ts
+++ b/frontend/src/app/band-events.service.ts
@@ -17,6 +17,20 @@ export class BandEventsService {
   constructor(private http: HttpClient) {}
 
   getUpcomingInGermany(band: string): Observable<Event[]> {
+    if (band.toUpperCase() === 'TESTBAND') {
+      return of([
+        {
+          datetime: new Date().toISOString(),
+          venue: {
+            country: 'Germany',
+            latitude: '52.5200',
+            longitude: '13.4050',
+            name: 'Berlin Arena',
+          },
+        },
+      ]);
+    }
+
     const url = `https://rest.bandsintown.com/artists/${encodeURIComponent(
       band
     )}/events?app_id=test`;

--- a/frontend/src/app/find-my-concert/band-concert-map.component.html
+++ b/frontend/src/app/find-my-concert/band-concert-map.component.html
@@ -1,2 +1,9 @@
 <h2>{{ band }}</h2>
-<div id="map" class="map"></div>
+<div class="container" [class.show-info]="selectedEvent">
+  <div id="map" class="map"></div>
+  <div class="info" *ngIf="selectedEvent">
+    <h3>{{ selectedEvent.venue.name }}</h3>
+    <p>{{ selectedEvent.datetime | date: 'longDate' }}</p>
+    <p>{{ selectedEvent.venue.country }}</p>
+  </div>
+</div>

--- a/frontend/src/app/find-my-concert/band-concert-map.component.scss
+++ b/frontend/src/app/find-my-concert/band-concert-map.component.scss
@@ -1,4 +1,32 @@
+.container {
+  position: relative;
+  width: 100%;
+  height: 70vh;
+  display: flex;
+  overflow: hidden;
+}
+
 .map {
+  flex: 1 0 100%;
   height: 70vh;
   border: 2px solid #333;
+  transition: transform 0.5s ease;
+}
+
+.info {
+  flex: 1 0 50%;
+  padding: 1rem;
+  background: #fff;
+  transform: translateX(100%);
+  opacity: 0;
+  transition: transform 0.5s ease, opacity 0.5s ease;
+}
+
+.container.show-info .map {
+  transform: translateX(-50%);
+}
+
+.container.show-info .info {
+  transform: translateX(0);
+  opacity: 1;
 }

--- a/frontend/src/app/find-my-concert/band-concert-map.component.ts
+++ b/frontend/src/app/find-my-concert/band-concert-map.component.ts
@@ -15,6 +15,15 @@ declare let L: any;
 export class BandConcertMapComponent implements OnInit, AfterViewInit {
   band = '';
   private map?: any;
+  selectedEvent?: {
+    datetime: string;
+    venue: {
+      country: string;
+      latitude: string;
+      longitude: string;
+      name: string;
+    };
+  };
 
   constructor(
     private route: ActivatedRoute,
@@ -24,6 +33,7 @@ export class BandConcertMapComponent implements OnInit, AfterViewInit {
   ngOnInit() {
     this.route.paramMap.subscribe((params) => {
       this.band = params.get('band') ?? '';
+      this.selectedEvent = undefined;
       if (this.map) {
         this.map.eachLayer((layer: any) => {
           if (layer instanceof L.Marker) {
@@ -56,6 +66,14 @@ export class BandConcertMapComponent implements OnInit, AfterViewInit {
           L.marker([lat, lng])
             .bindPopup(`${e.venue.name}`)
             .addTo(this.map);
+        }
+      }
+      if (events.length > 0) {
+        this.selectedEvent = events[0];
+        const lat = parseFloat(this.selectedEvent.venue.latitude);
+        const lng = parseFloat(this.selectedEvent.venue.longitude);
+        if (!isNaN(lat) && !isNaN(lng)) {
+          this.map.flyTo([lat, lng], 10, { animate: true, duration: 1.5 });
         }
       }
     });


### PR DESCRIPTION
## Summary
- animate map to concert location and slide left while displaying venue info
- mock band "TESTBAND" with Berlin event
- add unit test for TESTBAND mock

## Testing
- `npm test` *(fails: No binary for Chrome browser on your platform)*

------
https://chatgpt.com/codex/tasks/task_e_689baa14c2008326a6b3f59e3dfa5bef