### PR TITLE
feat: add Testband to default bands list

### DIFF
--- a/frontend/public/bands.json
+++ b/frontend/public/bands.json
@@ -1,4 +1,5 @@
 [
+  {"id":"testband","name":"Testband","imageUrl":"/images/band.svg"},
   {"id":"the-beatles","name":"The Beatles","imageUrl":"/images/band.svg"},
   {"id":"queen","name":"Queen","imageUrl":"/images/band.svg"},
   {"id":"pink-floyd","name":"Pink Floyd","imageUrl":"/images/band.svg"},


### PR DESCRIPTION
## Summary
- include **Testband** in bundled `bands.json` so users can search for it and trigger map animation

## Testing
- `npm test -- --watch=false` *(fails: No binary for Chrome browser on your platform)*
- `npm run build` *(fails: Failed to inline external stylesheet 'https://fonts.googleapis.com/css2?family=Noto+Music&display=swap'.)*

------
https://chatgpt.com/codex/tasks/task_e_689bafd3a2608326b1b0778bbd516005