### PR TITLE
feat: add band concert client route

### DIFF
--- a/frontend/src/app/app.routes.server.ts
+++ b/frontend/src/app/app.routes.server.ts
@@ -1,8 +1,6 @@
 import { RenderMode, ServerRoute } from '@angular/ssr';
 
 export const serverRoutes: ServerRoute[] = [
-  {
-    path: '**',
-    renderMode: RenderMode.Prerender
-  }
+  { path: 'find-my-concert/:band', renderMode: RenderMode.Client },
+  { path: '**', renderMode: RenderMode.Prerender }
 ];


### PR DESCRIPTION
## Summary
- add client-side route for band-specific concert page on server

## Testing
- `npm run build -- --configuration production --base-href "/Konzertkompass/"` *(fails: Inlining of fonts failed, status code 403)*

------
https://chatgpt.com/codex/tasks/task_e_689cd9724ab4832688f7a2df5d897d40